### PR TITLE
Issue 6.  Added a single message depending on state

### DIFF
--- a/packages/nextjs/components/scaffold-eth/RainbowKitCustomConnectButton/BatchDetails.tsx
+++ b/packages/nextjs/components/scaffold-eth/RainbowKitCustomConnectButton/BatchDetails.tsx
@@ -5,10 +5,15 @@ type BatchProps = {
   address: Address;
 };
 
+type Text = {
+  title: string;
+  message: string;
+};
+
 const zeroAddress = "0x0000000000000000000000000000000000000000";
 
 export const BatchDetails = ({ address }: BatchProps) => {
-  const { data: allowListed, isLoading: allowListLoading } = useScaffoldReadContract({
+  const { data: isAllowListed, isLoading: allowListLoading } = useScaffoldReadContract({
     contractName: "BatchRegistry",
     functionName: "allowList",
     args: [address],
@@ -20,14 +25,28 @@ export const BatchDetails = ({ address }: BatchProps) => {
     args: [address],
   });
 
+  const hasCheckedIn = zeroAddress !== checkedIn;
+
+  const getTextToShow = (): Text => {
+    if (isAllowListed) {
+      if (hasCheckedIn) {
+        return { title: "", message: "You are an up to date builder🥇" };
+      }
+      return { title: "Hey builder 🏗️!", message: "Remember to check in :)" };
+    }
+    return { title: "Oops!", message: "Reach us to be a builder" };
+  };
+
+  const textToShow = getTextToShow();
+
+  if (allowListLoading || checkedInLoading) {
+    return null;
+  }
+
   return (
-    <>
-      {!allowListLoading && !checkedInLoading && (
-        <div>
-          <span className="text-xs">{allowListed ? <p>✅ Allow Listed</p> : <p>❌ Not Allow Listed</p>}</span>
-          <span className="text-xs">{checkedIn != zeroAddress ? <p>✅ Checked in</p> : <p>❌ Not checked in</p>}</span>
-        </div>
-      )}
-    </>
+    <div className="bg-base-300  p-4 rounded shadow-lg">
+      <p className="text-lg m-0">{textToShow.title}</p>
+      <p className="text-sm m-0">{textToShow.message}</p>
+    </div>
   );
 };


### PR DESCRIPTION
## Description

This PR unifies the message UI depending of user state. Some pictures:


<img width="1383" alt="Captura de Pantalla 2024-09-17 a las 21 04 16" src="https://github.com/user-attachments/assets/8e342ba2-410a-47e1-91c5-5566aa39e543">
<img width="1386" alt="Captura de Pantalla 2024-09-17 a las 21 04 36" src="https://github.com/user-attachments/assets/476e715b-5b6c-4cf4-b2ed-0515fab74696">
<img width="1387" alt="Captura de Pantalla 2024-09-17 a las 21 04 50" src="https://github.com/user-attachments/assets/c1025c7e-a47d-48d6-9985-87296188b660">

## Additional Information

- [x] I have read the [contributing docs](/scaffold-eth/scaffold-eth-2/blob/main/CONTRIBUTING.md) (if this is your first contribution)
- [x] This is not a duplicate of any [existing pull request](https://github.com/scaffold-eth/scaffold-eth-2/pulls)

## Related Issues

_Closes #5_


Your ENS/address: 0xaa4C60b784E2b3E485035399bF1b1aBDeD66A60f
